### PR TITLE
Product pagination

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,6 +3,10 @@
   font-family: 'Open Sans', sans-serif;
 }
 
+.App{
+  margin-top: 80px;
+}
+
 .App-logo {
   animation: App-logo-spin infinite 20s linear;
   height: 40vmin;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,11 +7,13 @@ import productService from './product/ProductService';
 import { BrowserRouter as Router, Route, Link } from "react-router-dom";
 import { ProductDetailComponent } from './product/components/ProductDetailComponent';
 import { PaginationProducts } from './product/components/ProductPagination';
+import { AppBar } from './appBar/AppBar';
 
 class App extends Component {
   render() {
     return (
       <Router>
+        <AppBar />
         <div className="App">
           <Route exact path="/product/:id" component={ProductDetailComponent} />
           <Route exact path="/" component={PaginationProducts} />

--- a/src/appBar/AppBar.tsx
+++ b/src/appBar/AppBar.tsx
@@ -1,0 +1,18 @@
+import React, { Component } from 'react';
+
+import './appbar.css';
+
+export const AppBar = () => {
+    return (
+        <div className="app-bar">
+            <div className="app-bar-wrapper">
+                <div className="left-column">
+                    APP-BAR
+                </div> 
+                <div className="right-column">
+                    LEFT-BAR
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/appBar/appbar.css
+++ b/src/appBar/appbar.css
@@ -1,0 +1,22 @@
+.app-bar{
+    position: fixed;
+    left: 0;
+    top: 0;
+    background: #00bfd7;
+    width: 100%;
+    color: white;
+}
+
+.app-bar-wrapper{
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    padding: 12px;
+}
+
+.left-column{
+    text-align: left;
+}
+
+.right-column{
+    text-align: right;
+}

--- a/src/product/components/Product.tsx
+++ b/src/product/components/Product.tsx
@@ -34,9 +34,9 @@ export const ProductComponent = (productComponentProp: ProductComponentProp) => 
 
                 </div>
                 <CardActions>
-                    <Button variant="contained" color="primary" >Add To Cart</Button>
+                    <Button className="material-button add-cart" variant="contained" color="primary" >Add To Cart</Button>
                     <Link to={`/product/${productComponentProp.product.id}`}>
-                        <Button color="primary">View More</Button>
+                        <Button className="material-button view-more" color="primary">View More</Button>
                     </Link>
                 </CardActions>
             </CardContent>

--- a/src/product/components/ProductPagination.tsx
+++ b/src/product/components/ProductPagination.tsx
@@ -5,6 +5,7 @@ import queryString from 'query-string';
 import productService from '../ProductService';
 import { ProductsComponent } from './Product';
 
+import './productPagination.css';
 
 export interface ReactRouterMatch { match: match }
 export const PaginationProducts = (props: ReactRouterMatch) => {
@@ -16,7 +17,7 @@ export const PaginationProducts = (props: ReactRouterMatch) => {
   const products = productService.getPaginatedProducts(pageIndex);
 
   return (
-  <div>
+  <div className="PaginationProducts">
     <ProductsComponent products={products} />
     <PaginationCounter {...props} />
   </div>
@@ -36,7 +37,7 @@ export class PaginationCounter extends React.Component<ReactRouterMatch> {
       return (<div className="PaginationCounter">
         {[0, 1, 2, 3, 4].map(index => (
         <p className={`pagination-index ${index == page ? "selected-pagination-index": ""}`} key={index}>
-          <Link to={`/?page=${index}`}>{index}</Link>
+          {index == page ? <a>{index}</a> : <Link to={`/?page=${index}`}>{index}</Link>}
         </p>))}
       </div>);
     }

--- a/src/product/components/product.css
+++ b/src/product/components/product.css
@@ -42,3 +42,15 @@
     list-style: none;
     padding: 0px;
 }
+
+.material-button{
+    position: static !important;
+}
+
+.add-cart{
+    background: #00bbd3 !important;
+}
+
+.view-more{
+    /* color: #00bfd7 !important;; */
+}

--- a/src/product/components/productPagination.css
+++ b/src/product/components/productPagination.css
@@ -1,0 +1,29 @@
+
+
+.PaginationCounter > p{
+    display: inline-block;
+    margin: 8px;
+}
+
+.PaginationCounter * {
+    text-decoration: none;
+    font-size: 24px;
+}
+
+.PaginationCounter {
+    text-align: center;
+}
+
+
+
+.selected-pagination-index {
+    background: #00bbd3 !important;
+    color: black !important;
+    padding: 10px !important;
+    border-radius: 8px;
+
+}
+
+.selected-pagination-index a {
+    color: white;
+}


### PR DESCRIPTION
We don't want to see all the products displayed in the single page. What should happen is that we can list 10 products in the first page, and then show next 10 in the second and so on.

To display which page the user is in, we highlight the page count toward the bottom. 

![image](https://user-images.githubusercontent.com/8319308/55205474-68bc3b00-51a9-11e9-97fb-8da50f5a6336.png)

 